### PR TITLE
Nova LXD driver edits to support container migration 

### DIFF
--- a/nova/virt/lxd/driver.py
+++ b/nova/virt/lxd/driver.py
@@ -411,7 +411,7 @@ class LXDDriver(driver.ComputeDriver):
 
     capabilities = {
         "has_imagecache": False,
-        "supports_recreate": False,
+        "supports_recreate": True,
         "supports_migrate_to_same_host": False,
         "supports_attach_interface": True,
         "supports_multiattach": False,
@@ -1132,13 +1132,13 @@ class LXDDriver(driver.ComputeDriver):
 
         # Step 3 - Start the network and container
         self.plug_vifs(instance, network_info)
-        self.client.container.get(instance.name).start(wait=True)
+        self.client.containers.get(instance.name).start(wait=True)
 
-    def confirm_migration(self, migration, instance, network_info):
+    def confirm_migration(self, context, migration, instance, network_info):
         self.unplug_vifs(instance, network_info)
 
-        self.client.profiles.get(instance.name).delete()
         self.client.containers.get(instance.name).delete(wait=True)
+        self.client.profiles.get(instance.name).delete()
 
     def finish_revert_migration(self, context, instance, network_info,
                                 block_device_info=None, power_on=True):
@@ -1325,8 +1325,8 @@ class LXDDriver(driver.ComputeDriver):
     def _migrate(self, source_host, instance):
         """Migrate an instance from source."""
         source_client = pylxd.Client(
-            endpoint='https://{}'.format(source_host), verify=False)
+                endpoint='https://{}:8443'.format(source_host), verify=False)
         container = source_client.containers.get(instance.name)
         data = container.generate_migration_data()
 
-        self.containers.create(data, wait=True)
+        self.client.containers.create(data, wait=True)

--- a/nova/virt/lxd/driver.py
+++ b/nova/virt/lxd/driver.py
@@ -1325,7 +1325,7 @@ class LXDDriver(driver.ComputeDriver):
     def _migrate(self, source_host, instance):
         """Migrate an instance from source."""
         source_client = pylxd.Client(
-                endpoint='https://{}:8443'.format(source_host), verify=False)
+            endpoint='https://{}:8443'.format(source_host), verify=False)
         container = source_client.containers.get(instance.name)
         data = container.generate_migration_data()
 


### PR DESCRIPTION
The following edits have been made to the 'nova/virt/lxd/driver.py' file to fix cold migrations of LXD containers via openstack as outlined in PE-832.   One deviation was made (see first item) below to add ':8443' port number for the call made to pylxd client, which alleviated the need to fix this in 'pylxd/client.py' file.

Edits in  "/usr/lib/python2.7/dist-packages/nova/virt/lxd/driver.py":

(in function '_migrate') 
source_client = pylxd.Client(endpoint='https://{}'.format(source_host), verify=False)     
->  source_client = pylxd.Client(endpoint='https://{}:8443'.format(source_host), verify=False)

(in function '_migrate)')
self.containers.create(data, wait=True) 
-> self.client.containers.create(data, wait=True)

(in function '_finish_migration')
self.client.container.get(instance.name).start(wait=True)  
-> self.client.containers.get(instance.name).start(wait=True)

(in function 'confirm_migration')
def confirm_migration(self, migration, instance, network_info): 
->def confirm_migration(self, context, migration, instance, network_info):

(in function 'confirm_migration')
- reverse the order of profile/container deletes
self.client.profiles.get(instance.name).delete()
self.client.containers.get(instance.name).delete(wait=True)
-->
self.client.containers.get(instance.name).delete(wait=True)
self.client.profiles.get(instance.name).delete()*

(in 'LXDDriver' capabilities, change 'supports_recreate' to true)
capabilities = { ......  "supports_recreate": False, ......}
 ---> "supports_recreate": True,